### PR TITLE
Solve issue #42 (AIOpsLab)

### DIFF
--- a/hotelReservation/kubernetes/geo/geo-pvc.yaml
+++ b/hotelReservation/kubernetes/geo/geo-pvc.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   accessModes:
     - ReadWriteOnce
-  storageClassName: geo-storage
+  storageClassName: standard
   resources:
     requests:
       storage: 1Gi

--- a/hotelReservation/kubernetes/profile/profile-pvc.yaml
+++ b/hotelReservation/kubernetes/profile/profile-pvc.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   accessModes:
     - ReadWriteOnce
-  storageClassName: profile-storage
+  storageClassName: standard
   resources:
     requests:
       storage: 1Gi

--- a/hotelReservation/kubernetes/rate/rate-pvc.yaml
+++ b/hotelReservation/kubernetes/rate/rate-pvc.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   accessModes:
     - ReadWriteOnce
-  storageClassName: rate-storage
+  storageClassName: standard
   resources:
     requests:
       storage: 1Gi

--- a/hotelReservation/kubernetes/reccomend/recommendation-pvc.yaml
+++ b/hotelReservation/kubernetes/reccomend/recommendation-pvc.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   accessModes:
     - ReadWriteOnce
-  storageClassName: recommendation-storage
+  storageClassName: standard
   resources:
     requests:
       storage: 1Gi

--- a/hotelReservation/kubernetes/reserve/reservation-pvc.yaml
+++ b/hotelReservation/kubernetes/reserve/reservation-pvc.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   accessModes:
     - ReadWriteOnce
-  storageClassName: reservation-storage
+  storageClassName: standard
   resources:
     requests:
       storage: 1Gi

--- a/hotelReservation/kubernetes/user/user-pvc.yaml
+++ b/hotelReservation/kubernetes/user/user-pvc.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   accessModes:
     - ReadWriteOnce
-  storageClassName: user-storage
+  storageClassName: standard
   resources:
     requests:
       storage: 1Gi


### PR DESCRIPTION
Change the setting of hotel-reservation application to use "standard" storageClass to provision PVs dynamically. In this way, when PVCs are deleted, PVs will be cleaned up automatically.