### PR TITLE
Added a k8s version of Blueprint-compiled hotel reservation

### DIFF
--- a/BlueprintHotelReservation/kubernetes/frontend/frontend-service-deployment.yaml
+++ b/BlueprintHotelReservation/kubernetes/frontend/frontend-service-deployment.yaml
@@ -1,0 +1,42 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    kompose.cmd: kompose -f docker-compose-no-rpc.yml -o k8s-no-rpc/ -n blueprint-hotel
+      convert
+    kompose.image-pull-policy: Always
+    kompose.version: 1.37.0 (fb0539e64)
+  labels:
+    configmap: rpc
+    io.kompose.service: frontend-service
+  name: frontend-service
+
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      io.kompose.service: frontend-service
+  template:
+    metadata:
+      annotations:
+        kompose.cmd: kompose -f docker-compose-no-rpc.yml -o k8s-no-rpc/ -n blueprint-hotel
+          convert
+        kompose.image-pull-policy: Always
+        kompose.version: 1.37.0 (fb0539e64)
+      labels:
+        io.kompose.service: frontend-service
+    spec:
+      containers:
+      - envFrom:
+        - configMapRef:
+            name: frontend-service-container-env
+        - configMapRef:
+            name: rpc
+        image: 777lefty/docker-frontend-service-container:latest
+        imagePullPolicy: Always
+        name: frontend-service-container
+        ports:
+        - containerPort: 2000
+          protocol: TCP
+      hostname: frontend-service
+      restartPolicy: Always

--- a/BlueprintHotelReservation/kubernetes/frontend/frontend-service-env-configmap.yaml
+++ b/BlueprintHotelReservation/kubernetes/frontend/frontend-service-env-configmap.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+data:
+  FRONTEND_SERVICE_HTTP_BIND_ADDR: 0.0.0.0:2000
+  JAEGER_DIAL_ADDR: jaeger:14268
+  PROFILE_SERVICE_GRPC_DIAL_ADDR: profile-service:12345
+  RECOMD_SERVICE_GRPC_DIAL_ADDR: recomd-service:12345
+  RESERV_SERVICE_GRPC_DIAL_ADDR: reserv-service:12345
+  SEARCH_SERVICE_GRPC_DIAL_ADDR: search-service:12345
+  USER_SERVICE_GRPC_DIAL_ADDR: user-service:12345
+kind: ConfigMap
+metadata:
+  labels:
+    io.kompose.service: frontend-service-container-frontend-service-container-env
+  name: frontend-service-container-env

--- a/BlueprintHotelReservation/kubernetes/frontend/frontend-service-service.yaml
+++ b/BlueprintHotelReservation/kubernetes/frontend/frontend-service-service.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kompose.cmd: kompose -f docker-compose-no-rpc.yml -o k8s-no-rpc/ -n blueprint-hotel convert
+    kompose.image-pull-policy: Always
+    kompose.version: 1.37.0 (fb0539e64)
+  labels:
+    io.kompose.service: frontend-service
+  name: frontend-service
+
+spec:
+  ports:
+    - name: "12345"
+      port: 12345
+      targetPort: 2000
+    - name: "2000"
+      port: 2000
+      targetPort: 2000
+  selector:
+    io.kompose.service: frontend-service

--- a/BlueprintHotelReservation/kubernetes/geo/geo-db-deployment.yaml
+++ b/BlueprintHotelReservation/kubernetes/geo/geo-db-deployment.yaml
@@ -1,0 +1,36 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    kompose.cmd: kompose -f docker-compose-no-rpc.yml -o k8s-no-rpc/ -n blueprint-hotel
+      convert
+    kompose.image-pull-policy: Always
+    kompose.version: 1.37.0 (fb0539e64)
+  labels:
+    io.kompose.service: geo-db
+  name: geo-db
+
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      io.kompose.service: geo-db
+  template:
+    metadata:
+      annotations:
+        kompose.cmd: kompose -f docker-compose-no-rpc.yml -o k8s-no-rpc/ -n blueprint-hotel
+          convert
+        kompose.image-pull-policy: Always
+        kompose.version: 1.37.0 (fb0539e64)
+      labels:
+        io.kompose.service: geo-db
+    spec:
+      containers:
+      - image: mongo
+        imagePullPolicy: Always
+        name: geo-db-ctr
+        ports:
+        - containerPort: 27017
+          protocol: TCP
+      hostname: geo-db
+      restartPolicy: Always

--- a/BlueprintHotelReservation/kubernetes/geo/geo-db-service.yaml
+++ b/BlueprintHotelReservation/kubernetes/geo/geo-db-service.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kompose.cmd: kompose -f docker-compose-no-rpc.yml -o k8s-no-rpc/ -n blueprint-hotel convert
+    kompose.image-pull-policy: Always
+    kompose.version: 1.37.0 (fb0539e64)
+  labels:
+    io.kompose.service: geo-db
+  name: geo-db
+
+spec:
+  ports:
+    - name: "12346"
+      port: 12346
+      targetPort: 27017
+    - name: "27017"
+      port: 27017
+      targetPort: 27017
+  selector:
+    io.kompose.service: geo-db

--- a/BlueprintHotelReservation/kubernetes/geo/geo-service-deployment.yaml
+++ b/BlueprintHotelReservation/kubernetes/geo/geo-service-deployment.yaml
@@ -1,0 +1,42 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    kompose.cmd: kompose -f docker-compose-no-rpc.yml -o k8s-no-rpc/ -n blueprint-hotel
+      convert
+    kompose.image-pull-policy: Always
+    kompose.version: 1.37.0 (fb0539e64)
+  labels:
+    configmap: rpc
+    io.kompose.service: geo-service
+  name: geo-service
+
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      io.kompose.service: geo-service
+  template:
+    metadata:
+      annotations:
+        kompose.cmd: kompose -f docker-compose-no-rpc.yml -o k8s-no-rpc/ -n blueprint-hotel
+          convert
+        kompose.image-pull-policy: Always
+        kompose.version: 1.37.0 (fb0539e64)
+      labels:
+        io.kompose.service: geo-service
+    spec:
+      containers:
+      - envFrom:
+        - configMapRef:
+            name: geo-service-container-env
+        - configMapRef:
+            name: rpc
+        image: 777lefty/docker-geo-service-container:latest
+        imagePullPolicy: Always
+        name: geo-service-container
+        ports:
+        - containerPort: 12345
+          protocol: TCP
+      hostname: geo-service
+      restartPolicy: Always

--- a/BlueprintHotelReservation/kubernetes/geo/geo-service-env-configmap.yaml
+++ b/BlueprintHotelReservation/kubernetes/geo/geo-service-env-configmap.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+data:
+  GEO_DB_DIAL_ADDR: geo-db:27017
+  GEO_SERVICE_GRPC_BIND_ADDR: 0.0.0.0:12345
+  JAEGER_DIAL_ADDR: jaeger:14268
+kind: ConfigMap
+metadata:
+  labels:
+    io.kompose.service: geo-service-container-geo-service-container-env
+  name: geo-service-container-env

--- a/BlueprintHotelReservation/kubernetes/geo/geo-service-service.yaml
+++ b/BlueprintHotelReservation/kubernetes/geo/geo-service-service.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kompose.cmd: kompose -f docker-compose-no-rpc.yml -o k8s-no-rpc/ -n blueprint-hotel convert
+    kompose.image-pull-policy: Always
+    kompose.version: 1.37.0 (fb0539e64)
+  labels:
+    io.kompose.service: geo-service
+  name: geo-service
+
+spec:
+  ports:
+    - name: "12347"
+      port: 12347
+      targetPort: 12345
+    - name: "12345"
+      port: 12345
+      targetPort: 12345
+  selector:
+    io.kompose.service: geo-service

--- a/BlueprintHotelReservation/kubernetes/jaeger/jaeger-deployment.yaml
+++ b/BlueprintHotelReservation/kubernetes/jaeger/jaeger-deployment.yaml
@@ -1,0 +1,38 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    kompose.cmd: kompose -f docker-compose-no-rpc.yml -o k8s-no-rpc/ -n blueprint-hotel
+      convert
+    kompose.image-pull-policy: Always
+    kompose.version: 1.37.0 (fb0539e64)
+  labels:
+    io.kompose.service: jaeger
+  name: jaeger
+
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      io.kompose.service: jaeger
+  template:
+    metadata:
+      annotations:
+        kompose.cmd: kompose -f docker-compose-no-rpc.yml -o k8s-no-rpc/ -n blueprint-hotel
+          convert
+        kompose.image-pull-policy: Always
+        kompose.version: 1.37.0 (fb0539e64)
+      labels:
+        io.kompose.service: jaeger
+    spec:
+      containers:
+      - image: jaegertracing/all-in-one:latest
+        imagePullPolicy: Always
+        name: jaeger-ctr
+        ports:
+        - containerPort: 14268
+          protocol: TCP
+        - containerPort: 16686
+          protocol: TCP
+      hostname: jaeger
+      restartPolicy: Always

--- a/BlueprintHotelReservation/kubernetes/jaeger/jaeger-service.yaml
+++ b/BlueprintHotelReservation/kubernetes/jaeger/jaeger-service.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kompose.cmd: kompose -f docker-compose-no-rpc.yml -o k8s-no-rpc/ -n blueprint-hotel convert
+    kompose.image-pull-policy: Always
+    kompose.version: 1.37.0 (fb0539e64)
+  labels:
+    io.kompose.service: jaeger
+  name: jaeger
+
+spec:
+  type: NodePort
+  ports:
+    - name: "12348"
+      port: 12348
+      targetPort: 14268
+    - name: "12349"
+      port: 12349
+      targetPort: 16686
+    - name: "14268"
+      port: 14268
+      targetPort: 14268
+    - name: "16686"
+      port: 16686
+      targetPort: 16686
+  selector:
+    io.kompose.service: jaeger

--- a/BlueprintHotelReservation/kubernetes/profile/profile-cache-deployment.yaml
+++ b/BlueprintHotelReservation/kubernetes/profile/profile-cache-deployment.yaml
@@ -1,0 +1,36 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    kompose.cmd: kompose -f docker-compose-no-rpc.yml -o k8s-no-rpc/ -n blueprint-hotel
+      convert
+    kompose.image-pull-policy: Always
+    kompose.version: 1.37.0 (fb0539e64)
+  labels:
+    io.kompose.service: profile-cache
+  name: profile-cache
+
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      io.kompose.service: profile-cache
+  template:
+    metadata:
+      annotations:
+        kompose.cmd: kompose -f docker-compose-no-rpc.yml -o k8s-no-rpc/ -n blueprint-hotel
+          convert
+        kompose.image-pull-policy: Always
+        kompose.version: 1.37.0 (fb0539e64)
+      labels:
+        io.kompose.service: profile-cache
+    spec:
+      containers:
+      - image: memcached
+        imagePullPolicy: Always
+        name: profile-cache-ctr
+        ports:
+        - containerPort: 11211
+          protocol: TCP
+      hostname: profile-cache
+      restartPolicy: Always

--- a/BlueprintHotelReservation/kubernetes/profile/profile-cache-service.yaml
+++ b/BlueprintHotelReservation/kubernetes/profile/profile-cache-service.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kompose.cmd: kompose -f docker-compose-no-rpc.yml -o k8s-no-rpc/ -n blueprint-hotel convert
+    kompose.image-pull-policy: Always
+    kompose.version: 1.37.0 (fb0539e64)
+  labels:
+    io.kompose.service: profile-cache
+  name: profile-cache
+
+spec:
+  ports:
+    - name: "12350"
+      port: 12350
+      targetPort: 11211
+    - name: "11211"
+      port: 11211
+      targetPort: 11211
+  selector:
+    io.kompose.service: profile-cache

--- a/BlueprintHotelReservation/kubernetes/profile/profile-db-deployment.yaml
+++ b/BlueprintHotelReservation/kubernetes/profile/profile-db-deployment.yaml
@@ -1,0 +1,36 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    kompose.cmd: kompose -f docker-compose-no-rpc.yml -o k8s-no-rpc/ -n blueprint-hotel
+      convert
+    kompose.image-pull-policy: Always
+    kompose.version: 1.37.0 (fb0539e64)
+  labels:
+    io.kompose.service: profile-db
+  name: profile-db
+
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      io.kompose.service: profile-db
+  template:
+    metadata:
+      annotations:
+        kompose.cmd: kompose -f docker-compose-no-rpc.yml -o k8s-no-rpc/ -n blueprint-hotel
+          convert
+        kompose.image-pull-policy: Always
+        kompose.version: 1.37.0 (fb0539e64)
+      labels:
+        io.kompose.service: profile-db
+    spec:
+      containers:
+      - image: mongo
+        imagePullPolicy: Always
+        name: profile-db-ctr
+        ports:
+        - containerPort: 27017
+          protocol: TCP
+      hostname: profile-db
+      restartPolicy: Always

--- a/BlueprintHotelReservation/kubernetes/profile/profile-db-service.yaml
+++ b/BlueprintHotelReservation/kubernetes/profile/profile-db-service.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kompose.cmd: kompose -f docker-compose-no-rpc.yml -o k8s-no-rpc/ -n blueprint-hotel convert
+    kompose.image-pull-policy: Always
+    kompose.version: 1.37.0 (fb0539e64)
+  labels:
+    io.kompose.service: profile-db
+  name: profile-db
+
+spec:
+  ports:
+    - name: "12351"
+      port: 12351
+      targetPort: 27017
+    - name: "27017"
+      port: 27017
+      targetPort: 27017
+  selector:
+    io.kompose.service: profile-db

--- a/BlueprintHotelReservation/kubernetes/profile/profile-service-deployment.yaml
+++ b/BlueprintHotelReservation/kubernetes/profile/profile-service-deployment.yaml
@@ -1,0 +1,42 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    kompose.cmd: kompose -f docker-compose-no-rpc.yml -o k8s-no-rpc/ -n blueprint-hotel
+      convert
+    kompose.image-pull-policy: Always
+    kompose.version: 1.37.0 (fb0539e64)
+  labels:
+    configmap: rpc
+    io.kompose.service: profile-service
+  name: profile-service
+
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      io.kompose.service: profile-service
+  template:
+    metadata:
+      annotations:
+        kompose.cmd: kompose -f docker-compose-no-rpc.yml -o k8s-no-rpc/ -n blueprint-hotel
+          convert
+        kompose.image-pull-policy: Always
+        kompose.version: 1.37.0 (fb0539e64)
+      labels:
+        io.kompose.service: profile-service
+    spec:
+      containers:
+      - envFrom:
+        - configMapRef:
+            name: profile-service-container-env
+        - configMapRef:
+            name: rpc
+        image: 777lefty/docker-profile-service-container:latest
+        imagePullPolicy: Always
+        name: profile-service-container
+        ports:
+        - containerPort: 12345
+          protocol: TCP
+      hostname: profile-service
+      restartPolicy: Always

--- a/BlueprintHotelReservation/kubernetes/profile/profile-service-env-configmap.yaml
+++ b/BlueprintHotelReservation/kubernetes/profile/profile-service-env-configmap.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+data:
+  JAEGER_DIAL_ADDR: jaeger:14268
+  PROFILE_CACHE_DIAL_ADDR: profile-cache:11211
+  PROFILE_DB_DIAL_ADDR: profile-db:27017
+  PROFILE_SERVICE_GRPC_BIND_ADDR: 0.0.0.0:12345
+kind: ConfigMap
+metadata:
+  labels:
+    io.kompose.service: profile-service-container-profile-service-container-env
+  name: profile-service-container-env

--- a/BlueprintHotelReservation/kubernetes/profile/profile-service-service.yaml
+++ b/BlueprintHotelReservation/kubernetes/profile/profile-service-service.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kompose.cmd: kompose -f docker-compose-no-rpc.yml -o k8s-no-rpc/ -n blueprint-hotel convert
+    kompose.image-pull-policy: Always
+    kompose.version: 1.37.0 (fb0539e64)
+  labels:
+    io.kompose.service: profile-service
+  name: profile-service
+
+spec:
+  ports:
+    - name: "12352"
+      port: 12352
+      targetPort: 12345
+    - name: "12345"
+      port: 12345
+      targetPort: 12345
+  selector:
+    io.kompose.service: profile-service

--- a/BlueprintHotelReservation/kubernetes/rate/rate-cache-deployment.yaml
+++ b/BlueprintHotelReservation/kubernetes/rate/rate-cache-deployment.yaml
@@ -1,0 +1,36 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    kompose.cmd: kompose -f docker-compose-no-rpc.yml -o k8s-no-rpc/ -n blueprint-hotel
+      convert
+    kompose.image-pull-policy: Always
+    kompose.version: 1.37.0 (fb0539e64)
+  labels:
+    io.kompose.service: rate-cache
+  name: rate-cache
+
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      io.kompose.service: rate-cache
+  template:
+    metadata:
+      annotations:
+        kompose.cmd: kompose -f docker-compose-no-rpc.yml -o k8s-no-rpc/ -n blueprint-hotel
+          convert
+        kompose.image-pull-policy: Always
+        kompose.version: 1.37.0 (fb0539e64)
+      labels:
+        io.kompose.service: rate-cache
+    spec:
+      containers:
+      - image: memcached
+        imagePullPolicy: Always
+        name: rate-cache-ctr
+        ports:
+        - containerPort: 11211
+          protocol: TCP
+      hostname: rate-cache
+      restartPolicy: Always

--- a/BlueprintHotelReservation/kubernetes/rate/rate-cache-service.yaml
+++ b/BlueprintHotelReservation/kubernetes/rate/rate-cache-service.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kompose.cmd: kompose -f docker-compose-no-rpc.yml -o k8s-no-rpc/ -n blueprint-hotel convert
+    kompose.image-pull-policy: Always
+    kompose.version: 1.37.0 (fb0539e64)
+  labels:
+    io.kompose.service: rate-cache
+  name: rate-cache
+
+spec:
+  ports:
+    - name: "12353"
+      port: 12353
+      targetPort: 11211
+    - name: "11211"
+      port: 11211
+      targetPort: 11211
+  selector:
+    io.kompose.service: rate-cache

--- a/BlueprintHotelReservation/kubernetes/rate/rate-db-deployment.yaml
+++ b/BlueprintHotelReservation/kubernetes/rate/rate-db-deployment.yaml
@@ -1,0 +1,36 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    kompose.cmd: kompose -f docker-compose-no-rpc.yml -o k8s-no-rpc/ -n blueprint-hotel
+      convert
+    kompose.image-pull-policy: Always
+    kompose.version: 1.37.0 (fb0539e64)
+  labels:
+    io.kompose.service: rate-db
+  name: rate-db
+
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      io.kompose.service: rate-db
+  template:
+    metadata:
+      annotations:
+        kompose.cmd: kompose -f docker-compose-no-rpc.yml -o k8s-no-rpc/ -n blueprint-hotel
+          convert
+        kompose.image-pull-policy: Always
+        kompose.version: 1.37.0 (fb0539e64)
+      labels:
+        io.kompose.service: rate-db
+    spec:
+      containers:
+      - image: mongo
+        imagePullPolicy: Always
+        name: rate-db-ctr
+        ports:
+        - containerPort: 27017
+          protocol: TCP
+      hostname: rate-db
+      restartPolicy: Always

--- a/BlueprintHotelReservation/kubernetes/rate/rate-db-service.yaml
+++ b/BlueprintHotelReservation/kubernetes/rate/rate-db-service.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kompose.cmd: kompose -f docker-compose-no-rpc.yml -o k8s-no-rpc/ -n blueprint-hotel convert
+    kompose.image-pull-policy: Always
+    kompose.version: 1.37.0 (fb0539e64)
+  labels:
+    io.kompose.service: rate-db
+  name: rate-db
+
+spec:
+  ports:
+    - name: "12354"
+      port: 12354
+      targetPort: 27017
+    - name: "27017"
+      port: 27017
+      targetPort: 27017
+  selector:
+    io.kompose.service: rate-db

--- a/BlueprintHotelReservation/kubernetes/rate/rate-service-deployment.yaml
+++ b/BlueprintHotelReservation/kubernetes/rate/rate-service-deployment.yaml
@@ -1,0 +1,42 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    kompose.cmd: kompose -f docker-compose-no-rpc.yml -o k8s-no-rpc/ -n blueprint-hotel
+      convert
+    kompose.image-pull-policy: Always
+    kompose.version: 1.37.0 (fb0539e64)
+  labels:
+    configmap: rpc
+    io.kompose.service: rate-service
+  name: rate-service
+
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      io.kompose.service: rate-service
+  template:
+    metadata:
+      annotations:
+        kompose.cmd: kompose -f docker-compose-no-rpc.yml -o k8s-no-rpc/ -n blueprint-hotel
+          convert
+        kompose.image-pull-policy: Always
+        kompose.version: 1.37.0 (fb0539e64)
+      labels:
+        io.kompose.service: rate-service
+    spec:
+      containers:
+      - envFrom:
+        - configMapRef:
+            name: rate-service-container-env
+        - configMapRef:
+            name: rpc
+        image: 777lefty/docker-rate-service-container:latest
+        imagePullPolicy: Always
+        name: rate-service-container
+        ports:
+        - containerPort: 12345
+          protocol: TCP
+      hostname: rate-service
+      restartPolicy: Always

--- a/BlueprintHotelReservation/kubernetes/rate/rate-service-env-configmap.yaml
+++ b/BlueprintHotelReservation/kubernetes/rate/rate-service-env-configmap.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+data:
+  JAEGER_DIAL_ADDR: jaeger:14268
+  RATE_CACHE_DIAL_ADDR: rate-cache:11211
+  RATE_DB_DIAL_ADDR: rate-db:27017
+  RATE_SERVICE_GRPC_BIND_ADDR: 0.0.0.0:12345
+kind: ConfigMap
+metadata:
+  labels:
+    io.kompose.service: rate-service-container-rate-service-container-env
+  name: rate-service-container-env

--- a/BlueprintHotelReservation/kubernetes/rate/rate-service-service.yaml
+++ b/BlueprintHotelReservation/kubernetes/rate/rate-service-service.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kompose.cmd: kompose -f docker-compose-no-rpc.yml -o k8s-no-rpc/ -n blueprint-hotel convert
+    kompose.image-pull-policy: Always
+    kompose.version: 1.37.0 (fb0539e64)
+  labels:
+    io.kompose.service: rate-service
+  name: rate-service
+
+spec:
+  ports:
+    - name: "12355"
+      port: 12355
+      targetPort: 12345
+    - name: "12345"
+      port: 12345
+      targetPort: 12345
+  selector:
+    io.kompose.service: rate-service

--- a/BlueprintHotelReservation/kubernetes/recommend/recomd-db-deployment.yaml
+++ b/BlueprintHotelReservation/kubernetes/recommend/recomd-db-deployment.yaml
@@ -1,0 +1,36 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    kompose.cmd: kompose -f docker-compose-no-rpc.yml -o k8s-no-rpc/ -n blueprint-hotel
+      convert
+    kompose.image-pull-policy: Always
+    kompose.version: 1.37.0 (fb0539e64)
+  labels:
+    io.kompose.service: recomd-db
+  name: recomd-db
+
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      io.kompose.service: recomd-db
+  template:
+    metadata:
+      annotations:
+        kompose.cmd: kompose -f docker-compose-no-rpc.yml -o k8s-no-rpc/ -n blueprint-hotel
+          convert
+        kompose.image-pull-policy: Always
+        kompose.version: 1.37.0 (fb0539e64)
+      labels:
+        io.kompose.service: recomd-db
+    spec:
+      containers:
+      - image: mongo
+        imagePullPolicy: Always
+        name: recomd-db-ctr
+        ports:
+        - containerPort: 27017
+          protocol: TCP
+      hostname: recomd-db
+      restartPolicy: Always

--- a/BlueprintHotelReservation/kubernetes/recommend/recomd-db-service.yaml
+++ b/BlueprintHotelReservation/kubernetes/recommend/recomd-db-service.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kompose.cmd: kompose -f docker-compose-no-rpc.yml -o k8s-no-rpc/ -n blueprint-hotel convert
+    kompose.image-pull-policy: Always
+    kompose.version: 1.37.0 (fb0539e64)
+  labels:
+    io.kompose.service: recomd-db
+  name: recomd-db
+
+spec:
+  ports:
+    - name: "12356"
+      port: 12356
+      targetPort: 27017
+    - name: "27017"
+      port: 27017
+      targetPort: 27017
+  selector:
+    io.kompose.service: recomd-db

--- a/BlueprintHotelReservation/kubernetes/recommend/recomd-service-deployment.yaml
+++ b/BlueprintHotelReservation/kubernetes/recommend/recomd-service-deployment.yaml
@@ -1,0 +1,42 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    kompose.cmd: kompose -f docker-compose-no-rpc.yml -o k8s-no-rpc/ -n blueprint-hotel
+      convert
+    kompose.image-pull-policy: Always
+    kompose.version: 1.37.0 (fb0539e64)
+  labels:
+    configmap: rpc
+    io.kompose.service: recomd-service
+  name: recomd-service
+
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      io.kompose.service: recomd-service
+  template:
+    metadata:
+      annotations:
+        kompose.cmd: kompose -f docker-compose-no-rpc.yml -o k8s-no-rpc/ -n blueprint-hotel
+          convert
+        kompose.image-pull-policy: Always
+        kompose.version: 1.37.0 (fb0539e64)
+      labels:
+        io.kompose.service: recomd-service
+    spec:
+      containers:
+      - envFrom:
+        - configMapRef:
+            name: recomd-service-container-env
+        - configMapRef:
+            name: rpc
+        image: 777lefty/docker-recomd-service-container:latest
+        imagePullPolicy: Always
+        name: recomd-service-container
+        ports:
+        - containerPort: 12345
+          protocol: TCP
+      hostname: recomd-service
+      restartPolicy: Always

--- a/BlueprintHotelReservation/kubernetes/recommend/recomd-service-env-configmap.yaml
+++ b/BlueprintHotelReservation/kubernetes/recommend/recomd-service-env-configmap.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+data:
+  JAEGER_DIAL_ADDR: jaeger:14268
+  RECOMD_DB_DIAL_ADDR: recomd-db:27017
+  RECOMD_SERVICE_GRPC_BIND_ADDR: 0.0.0.0:12345
+kind: ConfigMap
+metadata:
+  labels:
+    io.kompose.service: recomd-service-container-recomd-service-container-env
+  name: recomd-service-container-env

--- a/BlueprintHotelReservation/kubernetes/recommend/recomd-service-service.yaml
+++ b/BlueprintHotelReservation/kubernetes/recommend/recomd-service-service.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kompose.cmd: kompose -f docker-compose-no-rpc.yml -o k8s-no-rpc/ -n blueprint-hotel convert
+    kompose.image-pull-policy: Always
+    kompose.version: 1.37.0 (fb0539e64)
+  labels:
+    io.kompose.service: recomd-service
+  name: recomd-service
+
+spec:
+  ports:
+    - name: "12357"
+      port: 12357
+      targetPort: 12345
+    - name: "12345"
+      port: 12345
+      targetPort: 12345
+  selector:
+    io.kompose.service: recomd-service

--- a/BlueprintHotelReservation/kubernetes/reservation/reserv-cache-deployment.yaml
+++ b/BlueprintHotelReservation/kubernetes/reservation/reserv-cache-deployment.yaml
@@ -1,0 +1,36 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    kompose.cmd: kompose -f docker-compose-no-rpc.yml -o k8s-no-rpc/ -n blueprint-hotel
+      convert
+    kompose.image-pull-policy: Always
+    kompose.version: 1.37.0 (fb0539e64)
+  labels:
+    io.kompose.service: reserv-cache
+  name: reserv-cache
+
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      io.kompose.service: reserv-cache
+  template:
+    metadata:
+      annotations:
+        kompose.cmd: kompose -f docker-compose-no-rpc.yml -o k8s-no-rpc/ -n blueprint-hotel
+          convert
+        kompose.image-pull-policy: Always
+        kompose.version: 1.37.0 (fb0539e64)
+      labels:
+        io.kompose.service: reserv-cache
+    spec:
+      containers:
+      - image: memcached
+        imagePullPolicy: Always
+        name: reserv-cache-ctr
+        ports:
+        - containerPort: 11211
+          protocol: TCP
+      hostname: reserv-cache
+      restartPolicy: Always

--- a/BlueprintHotelReservation/kubernetes/reservation/reserv-cache-service.yaml
+++ b/BlueprintHotelReservation/kubernetes/reservation/reserv-cache-service.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kompose.cmd: kompose -f docker-compose-no-rpc.yml -o k8s-no-rpc/ -n blueprint-hotel convert
+    kompose.image-pull-policy: Always
+    kompose.version: 1.37.0 (fb0539e64)
+  labels:
+    io.kompose.service: reserv-cache
+  name: reserv-cache
+
+spec:
+  ports:
+    - name: "12358"
+      port: 12358
+      targetPort: 11211
+    - name: "11211"
+      port: 11211
+      targetPort: 11211
+  selector:
+    io.kompose.service: reserv-cache

--- a/BlueprintHotelReservation/kubernetes/reservation/reserv-db-deployment.yaml
+++ b/BlueprintHotelReservation/kubernetes/reservation/reserv-db-deployment.yaml
@@ -1,0 +1,36 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    kompose.cmd: kompose -f docker-compose-no-rpc.yml -o k8s-no-rpc/ -n blueprint-hotel
+      convert
+    kompose.image-pull-policy: Always
+    kompose.version: 1.37.0 (fb0539e64)
+  labels:
+    io.kompose.service: reserv-db
+  name: reserv-db
+
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      io.kompose.service: reserv-db
+  template:
+    metadata:
+      annotations:
+        kompose.cmd: kompose -f docker-compose-no-rpc.yml -o k8s-no-rpc/ -n blueprint-hotel
+          convert
+        kompose.image-pull-policy: Always
+        kompose.version: 1.37.0 (fb0539e64)
+      labels:
+        io.kompose.service: reserv-db
+    spec:
+      containers:
+      - image: mongo
+        imagePullPolicy: Always
+        name: reserv-db-ctr
+        ports:
+        - containerPort: 27017
+          protocol: TCP
+      hostname: reserv-db
+      restartPolicy: Always

--- a/BlueprintHotelReservation/kubernetes/reservation/reserv-db-service.yaml
+++ b/BlueprintHotelReservation/kubernetes/reservation/reserv-db-service.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kompose.cmd: kompose -f docker-compose-no-rpc.yml -o k8s-no-rpc/ -n blueprint-hotel convert
+    kompose.image-pull-policy: Always
+    kompose.version: 1.37.0 (fb0539e64)
+  labels:
+    io.kompose.service: reserv-db
+  name: reserv-db
+
+spec:
+  ports:
+    - name: "12359"
+      port: 12359
+      targetPort: 27017
+    - name: "27017"
+      port: 27017
+      targetPort: 27017
+  selector:
+    io.kompose.service: reserv-db

--- a/BlueprintHotelReservation/kubernetes/reservation/reserv-service-deployment.yaml
+++ b/BlueprintHotelReservation/kubernetes/reservation/reserv-service-deployment.yaml
@@ -1,0 +1,42 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    kompose.cmd: kompose -f docker-compose-no-rpc.yml -o k8s-no-rpc/ -n blueprint-hotel
+      convert
+    kompose.image-pull-policy: Always
+    kompose.version: 1.37.0 (fb0539e64)
+  labels:
+    configmap: rpc
+    io.kompose.service: reserv-service
+  name: reserv-service
+
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      io.kompose.service: reserv-service
+  template:
+    metadata:
+      annotations:
+        kompose.cmd: kompose -f docker-compose-no-rpc.yml -o k8s-no-rpc/ -n blueprint-hotel
+          convert
+        kompose.image-pull-policy: Always
+        kompose.version: 1.37.0 (fb0539e64)
+      labels:
+        io.kompose.service: reserv-service
+    spec:
+      containers:
+      - envFrom:
+        - configMapRef:
+            name: reserv-service-container-env
+        - configMapRef:
+            name: rpc
+        image: 777lefty/docker-reserv-service-container:latest
+        imagePullPolicy: Always
+        name: reserv-service-container
+        ports:
+        - containerPort: 12345
+          protocol: TCP
+      hostname: reserv-service
+      restartPolicy: Always

--- a/BlueprintHotelReservation/kubernetes/reservation/reserv-service-env-configmap.yaml
+++ b/BlueprintHotelReservation/kubernetes/reservation/reserv-service-env-configmap.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+data:
+  JAEGER_DIAL_ADDR: jaeger:14268
+  RESERV_CACHE_DIAL_ADDR: reserv-cache:11211
+  RESERV_DB_DIAL_ADDR: reserv-db:27017
+  RESERV_SERVICE_GRPC_BIND_ADDR: 0.0.0.0:12345
+kind: ConfigMap
+metadata:
+  labels:
+    io.kompose.service: reserv-service-container-reserv-service-container-env
+  name: reserv-service-container-env

--- a/BlueprintHotelReservation/kubernetes/reservation/reserv-service-service.yaml
+++ b/BlueprintHotelReservation/kubernetes/reservation/reserv-service-service.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kompose.cmd: kompose -f docker-compose-no-rpc.yml -o k8s-no-rpc/ -n blueprint-hotel convert
+    kompose.image-pull-policy: Always
+    kompose.version: 1.37.0 (fb0539e64)
+  labels:
+    io.kompose.service: reserv-service
+  name: reserv-service
+
+spec:
+  ports:
+    - name: "12360"
+      port: 12360
+      targetPort: 12345
+    - name: "12345"
+      port: 12345
+      targetPort: 12345
+  selector:
+    io.kompose.service: reserv-service

--- a/BlueprintHotelReservation/kubernetes/rpc-configmap.yaml
+++ b/BlueprintHotelReservation/kubernetes/rpc-configmap.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+data:
+  GRPC_CLIENT_RETRIES_ON_ERROR: '1'
+  GRPC_CLIENT_TIMEOUT: 1s
+kind: ConfigMap
+metadata:
+  labels:
+    app: hotel-services
+    component: rpc-config
+  name: rpc

--- a/BlueprintHotelReservation/kubernetes/search/search-service-deployment.yaml
+++ b/BlueprintHotelReservation/kubernetes/search/search-service-deployment.yaml
@@ -1,0 +1,42 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    kompose.cmd: kompose -f docker-compose-no-rpc.yml -o k8s-no-rpc/ -n blueprint-hotel
+      convert
+    kompose.image-pull-policy: Always
+    kompose.version: 1.37.0 (fb0539e64)
+  labels:
+    configmap: rpc
+    io.kompose.service: search-service
+  name: search-service
+
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      io.kompose.service: search-service
+  template:
+    metadata:
+      annotations:
+        kompose.cmd: kompose -f docker-compose-no-rpc.yml -o k8s-no-rpc/ -n blueprint-hotel
+          convert
+        kompose.image-pull-policy: Always
+        kompose.version: 1.37.0 (fb0539e64)
+      labels:
+        io.kompose.service: search-service
+    spec:
+      containers:
+      - envFrom:
+        - configMapRef:
+            name: search-service-container-env
+        - configMapRef:
+            name: rpc
+        image: 777lefty/docker-search-service-container:latest
+        imagePullPolicy: Always
+        name: search-service-container
+        ports:
+        - containerPort: 12345
+          protocol: TCP
+      hostname: search-service
+      restartPolicy: Always

--- a/BlueprintHotelReservation/kubernetes/search/search-service-env-configmap.yaml
+++ b/BlueprintHotelReservation/kubernetes/search/search-service-env-configmap.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+data:
+  GEO_SERVICE_GRPC_DIAL_ADDR: geo-service:12345
+  JAEGER_DIAL_ADDR: jaeger:14268
+  RATE_SERVICE_GRPC_DIAL_ADDR: rate-service:12345
+  SEARCH_SERVICE_GRPC_BIND_ADDR: 0.0.0.0:12345
+kind: ConfigMap
+metadata:
+  labels:
+    io.kompose.service: search-service-container-search-service-container-env
+  name: search-service-container-env

--- a/BlueprintHotelReservation/kubernetes/search/search-service-service.yaml
+++ b/BlueprintHotelReservation/kubernetes/search/search-service-service.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kompose.cmd: kompose -f docker-compose-no-rpc.yml -o k8s-no-rpc/ -n blueprint-hotel convert
+    kompose.image-pull-policy: Always
+    kompose.version: 1.37.0 (fb0539e64)
+  labels:
+    io.kompose.service: search-service
+  name: search-service
+
+spec:
+  ports:
+    - name: "12361"
+      port: 12361
+      targetPort: 12345
+    - name: "12345"
+      port: 12345
+      targetPort: 12345
+  selector:
+    io.kompose.service: search-service

--- a/BlueprintHotelReservation/kubernetes/user/user-db-deployment.yaml
+++ b/BlueprintHotelReservation/kubernetes/user/user-db-deployment.yaml
@@ -1,0 +1,36 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    kompose.cmd: kompose -f docker-compose-no-rpc.yml -o k8s-no-rpc/ -n blueprint-hotel
+      convert
+    kompose.image-pull-policy: Always
+    kompose.version: 1.37.0 (fb0539e64)
+  labels:
+    io.kompose.service: user-db
+  name: user-db
+
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      io.kompose.service: user-db
+  template:
+    metadata:
+      annotations:
+        kompose.cmd: kompose -f docker-compose-no-rpc.yml -o k8s-no-rpc/ -n blueprint-hotel
+          convert
+        kompose.image-pull-policy: Always
+        kompose.version: 1.37.0 (fb0539e64)
+      labels:
+        io.kompose.service: user-db
+    spec:
+      containers:
+      - image: mongo
+        imagePullPolicy: Always
+        name: user-db-ctr
+        ports:
+        - containerPort: 27017
+          protocol: TCP
+      hostname: user-db
+      restartPolicy: Always

--- a/BlueprintHotelReservation/kubernetes/user/user-db-service.yaml
+++ b/BlueprintHotelReservation/kubernetes/user/user-db-service.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kompose.cmd: kompose -f docker-compose-no-rpc.yml -o k8s-no-rpc/ -n blueprint-hotel convert
+    kompose.image-pull-policy: Always
+    kompose.version: 1.37.0 (fb0539e64)
+  labels:
+    io.kompose.service: user-db
+  name: user-db
+
+spec:
+  ports:
+    - name: "12362"
+      port: 12362
+      targetPort: 27017
+    - name: "27017"
+      port: 27017
+      targetPort: 27017
+  selector:
+    io.kompose.service: user-db

--- a/BlueprintHotelReservation/kubernetes/user/user-service-deployment.yaml
+++ b/BlueprintHotelReservation/kubernetes/user/user-service-deployment.yaml
@@ -1,0 +1,42 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    kompose.cmd: kompose -f docker-compose-no-rpc.yml -o k8s-no-rpc/ -n blueprint-hotel
+      convert
+    kompose.image-pull-policy: Always
+    kompose.version: 1.37.0 (fb0539e64)
+  labels:
+    configmap: rpc
+    io.kompose.service: user-service
+  name: user-service
+
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      io.kompose.service: user-service
+  template:
+    metadata:
+      annotations:
+        kompose.cmd: kompose -f docker-compose-no-rpc.yml -o k8s-no-rpc/ -n blueprint-hotel
+          convert
+        kompose.image-pull-policy: Always
+        kompose.version: 1.37.0 (fb0539e64)
+      labels:
+        io.kompose.service: user-service
+    spec:
+      containers:
+      - envFrom:
+        - configMapRef:
+            name: user-service-container-env
+        - configMapRef:
+            name: rpc
+        image: 777lefty/docker-user-service-container:latest
+        imagePullPolicy: Always
+        name: user-service-container
+        ports:
+        - containerPort: 12345
+          protocol: TCP
+      hostname: user-service
+      restartPolicy: Always

--- a/BlueprintHotelReservation/kubernetes/user/user-service-env-configmap.yaml
+++ b/BlueprintHotelReservation/kubernetes/user/user-service-env-configmap.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+data:
+  JAEGER_DIAL_ADDR: jaeger:14268
+  USER_DB_DIAL_ADDR: user-db:27017
+  USER_SERVICE_GRPC_BIND_ADDR: 0.0.0.0:12345
+kind: ConfigMap
+metadata:
+  labels:
+    io.kompose.service: user-service-container-user-service-container-env
+  name: user-service-container-env

--- a/BlueprintHotelReservation/kubernetes/user/user-service-service.yaml
+++ b/BlueprintHotelReservation/kubernetes/user/user-service-service.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kompose.cmd: kompose -f docker-compose-no-rpc.yml -o k8s-no-rpc/ -n blueprint-hotel convert
+    kompose.image-pull-policy: Always
+    kompose.version: 1.37.0 (fb0539e64)
+  labels:
+    io.kompose.service: user-service
+  name: user-service
+
+spec:
+  ports:
+    - name: "12363"
+      port: 12363
+      targetPort: 12345
+    - name: "12345"
+      port: 12345
+      targetPort: 12345
+  selector:
+    io.kompose.service: user-service

--- a/BlueprintHotelReservation/wlgen/wlgen_proc-configmap.yaml
+++ b/BlueprintHotelReservation/wlgen/wlgen_proc-configmap.yaml
@@ -4,8 +4,11 @@ data:
   JAEGER_DIAL_ADDR: jaeger.blueprint-hotel-reservation:12348
   OUTFILE: stats.csv
   DURATION: 120s
-  TPUT: '1000'
+  TPUT: '3000'
   MULTIPLIER: '6'
+  STABLETIME: '60'
+  TRIGGERTIME: '30'
+  REVERTTIME: '30'
 
 kind: ConfigMap
 metadata:

--- a/BlueprintHotelReservation/wlgen/wlgen_proc-configmap.yaml
+++ b/BlueprintHotelReservation/wlgen/wlgen_proc-configmap.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+data:
+  FRONTEND_SERVICE_HTTP_DIAL_ADDR: frontend-service.blueprint-hotel-reservation:12345
+  JAEGER_DIAL_ADDR: jaeger.blueprint-hotel-reservation:12348
+  OUTFILE: stats.csv
+  DURATION: 120s
+  TPUT: '1000'
+  MULTIPLIER: '6'
+
+kind: ConfigMap
+metadata:
+  labels:
+    io.kompose.service: bhotelwrk-wlgen-env
+  name: bhotelwrk-wlgen-env

--- a/BlueprintHotelReservation/wlgen/wlgen_proc-job.yaml
+++ b/BlueprintHotelReservation/wlgen/wlgen_proc-job.yaml
@@ -1,0 +1,24 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: bhotelwrk-wlgen-job
+spec:
+  backoffLimit: 0   # 出错不重试
+  template:
+    metadata:
+      labels:
+          job-name: bhotelwrk-wlgen-job
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: wlgen
+        image: 777lefty/wlgen-proc:latest
+        imagePullPolicy: Always
+        envFrom:
+        - configMapRef:
+            name: bhotelwrk-wlgen-env
+        command: ["/bin/sh", "-c"]
+        args:
+          - |
+            echo "🚀 Running wlgen_proc with FRONTEND_SERVICE_HTTP_DIAL_ADDR=$FRONTEND_SERVICE_HTTP_DIAL_ADDR and JAEGER_DIAL_ADDR=$JAEGER_DIAL_ADDR"
+            /app/wlgen_proc --outfile $OUTFILE --duration $DURATION --tput $TPUT --multiplier $MULTIPLIER

--- a/BlueprintHotelReservation/wlgen/wlgen_proc-job.yaml
+++ b/BlueprintHotelReservation/wlgen/wlgen_proc-job.yaml
@@ -3,7 +3,7 @@ kind: Job
 metadata:
   name: bhotelwrk-wlgen-job
 spec:
-  backoffLimit: 0   # 出错不重试
+  backoffLimit: 0   
   template:
     metadata:
       labels:
@@ -21,4 +21,4 @@ spec:
         args:
           - |
             echo "🚀 Running wlgen_proc with FRONTEND_SERVICE_HTTP_DIAL_ADDR=$FRONTEND_SERVICE_HTTP_DIAL_ADDR and JAEGER_DIAL_ADDR=$JAEGER_DIAL_ADDR"
-            /app/wlgen_proc --outfile $OUTFILE --duration $DURATION --tput $TPUT --multiplier $MULTIPLIER
+            /app/wlgen_proc --outfile $OUTFILE --duration $DURATION --tput $TPUT --multiplier $MULTIPLIER --stabletime $STABLETIME --triggertime $TRIGGERTIME --reverttime $REVERTTIME


### PR DESCRIPTION
Added a k8s version of Blueprint-compiled hotel reservation, for the newly registered problem `rpc_retry_storm`, please merge it if the problem is used.